### PR TITLE
Update assert.yml to conditionally check user and password

### DIFF
--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -22,6 +22,7 @@
       - grub_password is defined
       - grub_password is search('grub.pbkdf2.sha512')
     quiet: yes
+  when: grub_superuser is defined and grub_password is defined
 
 - name: Test if grub_options_present is set correctly
   ansible.builtin.assert:


### PR DESCRIPTION
What if a grub user and password is not desired?  So patch only asserts that a user and password for grub are set, if one or the other variables are defined.  Then the full checks can be performed to make sure both are valid in the assertion.  Otherwise, no user and password combination is asserted.