### PR TITLE
Update options_mgmt.yml to support --check mode

### DIFF
--- a/tasks/options_mgmt.yml
+++ b/tasks/options_mgmt.yml
@@ -9,6 +9,7 @@
   args:
     executable: /bin/bash
   register: grub_current_cmdline
+  check_mode: no
   changed_when: false
 
 - name: Transform retrieved option as a list of options


### PR DESCRIPTION
By adding check_mode: no, the command will run even in --check mode which is safe because it doesn't make changes.  The role fails in check mode without this patch as the current grub cmdline is not retrieved, and is needed in the subsequent tasks.